### PR TITLE
Fix static lib build error in Xcode12.5

### DIFF
--- a/Source/ViewControllerPresentationSpy/UIViewController+QCOMock.m
+++ b/Source/ViewControllerPresentationSpy/UIViewController+QCOMock.m
@@ -5,7 +5,11 @@
 
 #import "NSObject+QCOMockAlerts.h"
 #import "UIAlertController+QCOMock.h"
-#import <ViewControllerPresentationSpy/ViewControllerPresentationSpy-Swift.h>
+#if __has_include("ViewControllerPresentationSpy-Swift.h")
+    #import "ViewControllerPresentationSpy-Swift.h"
+#else
+    #import <ViewControllerPresentationSpy/ViewControllerPresentationSpy-Swift.h>
+#endif
 
 NSString *const QCOMockViewControllerPresentingViewControllerKey = @"QCOMockViewControllerPresentingViewControllerKey";
 NSString *const QCOMockViewControllerAnimatedKey = @"QCOMockViewControllerAnimatedKey";

--- a/ViewControllerPresentationSpy.podspec
+++ b/ViewControllerPresentationSpy.podspec
@@ -26,6 +26,9 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.swift_version = "5.0"
   s.weak_framework = "XCTest"
+  s.pod_target_xcconfig = {
+    "ENABLE_TESTING_SEARCH_PATHS" => "YES" # Required for Xcode 12.5
+  }
   s.user_target_xcconfig = {
     'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"',
   }


### PR DESCRIPTION
Fix error:

- Link SCTest error
- ViewControllerPresentationSpy/ViewControllerPresentationSpy-Swift.h' file not found

So, #6 #8 fixed.
